### PR TITLE
feat: render menu text sharply on high-DPI displays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,6 +1413,7 @@ dependencies = [
  "unicase",
  "uord",
  "vecmath",
+ "windows-sys 0.61.2",
  "zip",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,7 +922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1413,7 +1413,7 @@ dependencies = [
  "unicase",
  "uord",
  "vecmath",
- "windows-sys 0.61.2",
+ "windows",
  "zip",
 ]
 
@@ -1428,7 +1428,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -2599,7 +2599,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2861,7 +2861,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3407,6 +3407,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3416,10 +3438,90 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-sys"
@@ -3436,7 +3538,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3453,6 +3555,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,4 +50,4 @@ debug = "full"
 debug-mode = []
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_UI_HiDpi"] }
+windows = { version = "0.61", features = ["Win32_UI_HiDpi"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,6 @@ debug = "full"
 
 [features]
 debug-mode = []
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_UI_HiDpi"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -225,14 +225,13 @@ impl EventHandler for App {
 
 impl App {
   fn update_font_dpi(&mut self, viewport: Viewport) {
-    let scale = viewport.draw_size[0] as f64 / viewport.window_size[0];
-    font::set_dpi_scale(scale);
+    font::set_dpi_scale(viewport.draw_size[0] as f64 / viewport.window_size[0]);
 
-    let render_font_size = font::render_font_size();
-    if render_font_size != self.current_render_font_size {
-      self.glyph_cache.preload_printable_ascii(render_font_size)
+    let new_render_font_size = font::render_font_size();
+    if new_render_font_size != self.current_render_font_size {
+      self.glyph_cache.preload_printable_ascii(new_render_font_size)
         .expect("unable to preload font glyphs");
-      self.current_render_font_size = render_font_size;
+      self.current_render_font_size = new_render_font_size;
     };
   }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -69,21 +69,24 @@ pub struct App {
   pub alerts: Alerts,
   pub glyph_cache: FontGlyphCache,
   pub interface: Option<Interface>,
-  pub painting: bool
+  pub painting: bool,
+  pub current_render_font_size: u32
 }
 
 impl EventHandler for App {
   fn new(_gl: &mut GlGraphics) -> Self {
     let texture_settings = TextureSettings::new().filter(Filter::Nearest);
     let mut glyph_cache = GlyphCache::from_font(font::get_font(), (), texture_settings);
-    glyph_cache.preload_printable_ascii(font::FONT_SIZE).expect("unable to preload font glyphs");
+    let render_font_size = font::render_font_size();
+    glyph_cache.preload_printable_ascii(render_font_size).expect("unable to preload font glyphs");
 
     App {
       canvas: None,
       alerts: Alerts::new(5.0),
       glyph_cache,
       interface: None,
-      painting: false
+      painting: false,
+      current_render_font_size: render_font_size
     }
   }
 
@@ -100,6 +103,7 @@ impl EventHandler for App {
 
   fn on_render(&mut self, ctx: Context, cursor_pos: Option<Vector2<f64>>, gl: &mut GlGraphics) {
     let Some(viewport) = ctx.viewport else { return };
+    self.update_font_dpi(viewport);
     let ictx = self.get_interface_draw_context();
     let interface = &*get_interface(&mut self.interface, viewport);
     graphics::clear(colors::NEUTRAL, gl);
@@ -198,6 +202,7 @@ impl EventHandler for App {
   }
 
   fn on_resize(&mut self, viewport: Viewport) {
+    self.update_font_dpi(viewport);
     self.interface = Some(Interface::new(viewport));
   }
 
@@ -219,6 +224,18 @@ impl EventHandler for App {
 }
 
 impl App {
+  fn update_font_dpi(&mut self, viewport: Viewport) {
+    let scale = viewport.draw_size[0] as f64 / viewport.window_size[0];
+    font::set_dpi_scale(scale);
+
+    let render_font_size = font::render_font_size();
+    if render_font_size != self.current_render_font_size {
+      self.glyph_cache.preload_printable_ascii(render_font_size)
+        .expect("unable to preload font glyphs");
+      self.current_render_font_size = render_font_size;
+    };
+  }
+
   fn get_interface_draw_context(&self) -> InterfaceDrawContext {
     match &self.canvas {
       Some(canvas) => InterfaceDrawContext {

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,9 +6,11 @@ pub mod map;
 
 use defy::Contextualize;
 use glutin::window::CursorIcon;
+use graphics::Transformed;
 use graphics::Viewport;
 use graphics::context::Context;
 use graphics::glyph_cache::rusttype::GlyphCache;
+use graphics::types::Color as DrawColor;
 use opengl_graphics::{GlGraphics, Filter, Texture, TextureSettings};
 use piston::input::{Key, MouseButton};
 use vecmath::Vector2;
@@ -64,13 +66,30 @@ pub mod colors {
 
 pub type FontGlyphCache = GlyphCache<'static, (), Texture>;
 
+fn draw_text(
+  ctx: Context,
+  color: DrawColor,
+  pos: Vector2<f64>,
+  text: &str,
+  glyph_cache: &mut FontGlyphCache,
+  gl: &mut GlGraphics
+) {
+  let dpi_scale = font::dpi_scale() as f64;
+  let pos = [pos[0].round(), pos[1].round()];
+  let transform = ctx.transform.trans_pos(pos).scale(1.0 / dpi_scale, 1.0 / dpi_scale);
+  graphics::Text::new_color(color, font::render_font_size())
+    .round()
+    .draw(text, glyph_cache, &ctx.draw_state, transform, gl)
+    .expect("unable to draw text");
+}
+
 pub struct App {
   pub canvas: Option<Canvas>,
   pub alerts: Alerts,
   pub glyph_cache: FontGlyphCache,
   pub interface: Option<Interface>,
   pub painting: bool,
-  pub current_render_font_size: u32
+  current_render_font_size: u32
 }
 
 impl EventHandler for App {
@@ -202,7 +221,6 @@ impl EventHandler for App {
   }
 
   fn on_resize(&mut self, viewport: Viewport) {
-    self.update_font_dpi(viewport);
     self.interface = Some(Interface::new(viewport));
   }
 

--- a/src/app/alerts.rs
+++ b/src/app/alerts.rs
@@ -1,11 +1,10 @@
-use graphics::Transformed;
 use graphics::context::Context;
 use graphics::types::Color as DrawColor;
 use opengl_graphics::GlGraphics;
 
-use super::{colors, FontGlyphCache};
+use super::{colors, FontGlyphCache, draw_text};
 use super::interface::Interface;
-use crate::font::{self, FONT_SIZE};
+use crate::font;
 
 use std::collections::VecDeque;
 
@@ -78,9 +77,7 @@ impl Alerts {
       for (i, (text, color)) in self.iter_all().enumerate() {
         let x = PADDING[0] + interface.get_sidebar_width() as f64;
         let y = height - i as f64 * font_height;
-        let t = ctx.transform.trans(x, y);
-        graphics::text(color, FONT_SIZE, text, glyph_cache, t, gl)
-          .expect("unable to draw text");
+        draw_text(ctx, color, [x, y], text, glyph_cache, gl);
       };
     } else {
       let height = self.len() as f64 * font_height + PADDING[1] + interface.get_toolbar_height() as f64;
@@ -89,9 +86,7 @@ impl Alerts {
       for (i, (text, color)) in self.iter().enumerate() {
         let x = PADDING[0] + interface.get_sidebar_width() as f64;
         let y = height - i as f64 * font_height;
-        let t = ctx.transform.trans(x, y);
-        graphics::text(color, FONT_SIZE, text, glyph_cache, t, gl)
-          .expect("unable to draw text");
+        draw_text(ctx, color, [x, y], text, glyph_cache, gl);
       };
     };
   }

--- a/src/app/canvas.rs
+++ b/src/app/canvas.rs
@@ -9,13 +9,13 @@ use opengl_graphics::{Filter, GlGraphics, Texture, TextureSettings};
 use uord::UOrd2 as UOrd;
 use vecmath::{Matrix2x3, Vector2};
 
-use super::{colors, FontGlyphCache};
+use super::{colors, FontGlyphCache, draw_text};
 use super::alerts::Alerts;
 use super::map::*;
 use super::interface::Interface;
 use super::format::DefinitionKind;
 use crate::config::Config;
-use crate::font::{self, FONT_SIZE};
+use crate::font;
 use crate::util::stringify_color;
 use crate::util::files::Location;
 use crate::error::Error;
@@ -135,9 +135,7 @@ impl Canvas {
 
     let camera_info = self.camera_info(interface, cursor_pos);
     let pos = [PADDING[0] + interface.get_sidebar_width() as f64, interface.get_window_size()[1] - PADDING[1] * 1.25];
-    let transform = ctx.transform.trans_pos(pos);
-    graphics::text(colors::WHITE, FONT_SIZE, &camera_info, glyph_cache, transform, gl)
-      .expect("unable to draw text");
+    draw_text(ctx, colors::WHITE, pos, &camera_info, glyph_cache, gl);
   }
 
   fn draw_ids(&self, ctx: Context, interface: &Interface, glyph_cache: &mut FontGlyphCache, gl: &mut GlGraphics) {
@@ -165,9 +163,8 @@ impl Canvas {
           font::get_width_metric_str(&preserved_id) / -2.0,
           font::get_v_metrics().ascent - font::get_height_metric() / 2.0
         ];
-        let transform = ctx.transform.trans_pos(center_of_mass).trans_pos(offset);
-        graphics::text(color, FONT_SIZE, &preserved_id, glyph_cache, transform, gl)
-          .expect("unable to draw text");
+        let pos = vecmath::vec2_add(center_of_mass, offset);
+        draw_text(ctx, color, pos, &preserved_id, glyph_cache, gl);
       };
     };
   }

--- a/src/app/interface.rs
+++ b/src/app/interface.rs
@@ -11,12 +11,14 @@ use vecmath::Vector2;
 use crate::font;
 use super::canvas::ViewMode;
 use super::colors;
-use super::{FontGlyphCache, InterfaceDrawContext};
+use super::{FontGlyphCache, InterfaceDrawContext, draw_text};
 
 use std::sync::Arc;
 use std::fmt;
 
 pub const PADDING: Vector2<f64> = [6.0, 4.0];
+const TOOLTIP_OFFSET_X: f64 = 8.0;
+const TOOLTIP_MIN_WIDTH: f64 = 180.0;
 
 #[inline]
 fn snap_pos([x, y]: Vector2<f64>) -> Vector2<f64> {
@@ -208,6 +210,7 @@ impl Interface {
     glyph_cache: &mut FontGlyphCache,
     gl: &mut GlGraphics
   ) {
+    let mut sidebar_tooltip = None;
     self.sidebar_plate.draw(ctx, false, false, gl);
 
     for (i, sidebar_button) in self.sidebar_tool_buttons.iter().enumerate() {
@@ -222,15 +225,27 @@ impl Interface {
       };
 
       let hover = sidebar_button.base.test_maybe(pos);
+      if hover {
+        sidebar_tooltip = sidebar_button.tooltip(ictx.view_mode)
+          .map(|text| (sidebar_button.base.tooltip_anchor(), text));
+      }
       let active = Some(i) == selected_tool;
       sidebar_button.base.draw(ctx, hover, active, glyph_cache, gl);
     };
 
     for (i, sidebar_button) in self.sidebar_option_buttons.iter().enumerate() {
       let hover = sidebar_button.base.test_maybe(pos);
+      if hover {
+        sidebar_tooltip = sidebar_button.tooltip(ictx.view_mode)
+          .map(|text| (sidebar_button.base.tooltip_anchor(), text));
+      }
       let active = ictx.enabled_options[i];
       sidebar_button.base.draw(ctx, hover, active, glyph_cache, gl);
     };
+
+    if let Some((anchor, text)) = sidebar_tooltip {
+      draw_tooltip(ctx, text, anchor, glyph_cache, gl);
+    }
 
     self.toolbar_plate.draw(ctx, false, false, gl);
 
@@ -262,6 +277,33 @@ impl ButtonElement {
 
   fn draw(&self, ctx: Context, pos: Option<Vector2<f64>>, active: bool, glyph_cache: &mut FontGlyphCache, gl: &mut GlGraphics) {
     self.base.draw(ctx, self.base.test_maybe(pos), active, glyph_cache, gl);
+  }
+
+  fn tooltip(&self, view_mode: Option<ViewMode>) -> Option<&'static str> {
+    use ButtonId::*;
+    let view_mode = view_mode?;
+
+    match (self.id, view_mode) {
+      (SidebarToolPaintArea, ViewMode::Color) =>
+        Some("Paint Area: Drag to paint provinces under the brush"),
+      (SidebarToolPaintArea, ViewMode::Kind) =>
+        Some("Paint Area: Drag to assign province types"),
+      (SidebarToolPaintArea, ViewMode::Terrain) =>
+        Some("Paint Area: Drag to assign province terrain types"),
+      (SidebarToolPaintArea, ViewMode::Continent) =>
+        Some("Paint Area: Drag to assign provinces to continents"),
+      (SidebarToolPaintBucket, ViewMode::Color) =>
+        Some("Paint Bucket: Fill the hovered province with the current brush"),
+      (SidebarToolLasso, ViewMode::Color) =>
+        Some("Lasso: Draw a custom selection and then apply the current brush"),
+      (SidebarOptionProvinceIds, ..) =>
+        Some("Toggle Province IDs: Show or hide province IDs on the map"),
+      (SidebarOptionProvinceBoundaries, ..) =>
+        Some("Toggle Province Boundaries: Show or hide province borders"),
+      (SidebarOptionRiverOverlay, ..) =>
+        Some("Toggle Rivers Overlay: Show or hide the contents of rivers.bmp"),
+      _ => None
+    }
   }
 }
 
@@ -404,6 +446,11 @@ impl ButtonBase {
       ButtonBase::BoxTexture { plate, .. } => plate
     }
   }
+
+  fn tooltip_anchor(&self) -> Vector2<f64> {
+    let plate = self.plate();
+    [plate.pos[0] + plate.size[0], plate.pos[1] + plate.size[1] / 2.0]
+  }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -414,12 +461,7 @@ struct TextComponent {
 
 impl TextComponent {
   fn draw(&self, ctx: Context, colors: &Palette, glyph_cache: &mut FontGlyphCache, gl: &mut GlGraphics) {
-    let dpi_scale = font::dpi_scale() as f64;
-    let transform = ctx.transform.trans_pos(self.pos).scale(1.0 / dpi_scale, 1.0 / dpi_scale);
-    graphics::Text::new_color(colors.foreground, font::render_font_size())
-      .round()
-      .draw(self.text, glyph_cache, &ctx.draw_state, transform, gl)
-      .expect("unable to draw text");
+    draw_text(ctx, colors.foreground, self.pos, self.text, glyph_cache, gl);
   }
 }
 
@@ -499,6 +541,28 @@ struct Palette {
   background_active: DrawColor,
   background_hover: DrawColor,
   background_hover_active: DrawColor
+}
+
+fn draw_tooltip(
+  ctx: Context,
+  text: &'static str,
+  anchor: Vector2<f64>,
+  glyph_cache: &mut FontGlyphCache,
+  gl: &mut GlGraphics
+) {
+  let v_metrics = font::get_v_metrics();
+  let text_width = font::get_width_metric_str(text).round();
+  let plate_width = text_width.max(TOOLTIP_MIN_WIDTH) + PADDING[0] * 2.0;
+  let plate_height = (v_metrics.ascent - v_metrics.descent + PADDING[1] * 2.0).round();
+  let plate_pos = snap_pos([anchor[0] + TOOLTIP_OFFSET_X, anchor[1] - plate_height / 2.0]);
+  let text_pos = snap_pos([plate_pos[0] + PADDING[0], plate_pos[1] + PADDING[1] + v_metrics.ascent]);
+
+  graphics::rectangle(colors::OVERLAY_T, [
+    plate_pos[0], plate_pos[1],
+    plate_width, plate_height
+  ], ctx.transform, gl);
+
+  draw_text(ctx, colors::WHITE, text_pos, text, glyph_cache, gl);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/src/app/interface.rs
+++ b/src/app/interface.rs
@@ -8,7 +8,7 @@ use once_cell::sync::Lazy;
 use opengl_graphics::{Texture, TextureSettings, GlGraphics};
 use vecmath::Vector2;
 
-use crate::font::{self, FONT_SIZE};
+use crate::font;
 use super::canvas::ViewMode;
 use super::colors;
 use super::{FontGlyphCache, InterfaceDrawContext};
@@ -17,6 +17,11 @@ use std::sync::Arc;
 use std::fmt;
 
 pub const PADDING: Vector2<f64> = [6.0, 4.0];
+
+#[inline]
+fn snap_pos([x, y]: Vector2<f64>) -> Vector2<f64> {
+  [x.round(), y.round()]
+}
 
 const PALETTE_BUTTON: Palette = Palette {
   foreground: colors::WHITE,
@@ -52,7 +57,7 @@ pub struct Interface {
 
 impl Interface {
   pub fn new(viewport: Viewport) -> Self {
-    let [window_width, window_height] = viewport.draw_size;
+    let [window_width, window_height] = viewport.window_size;
 
     let mut pos_x = 0;
     let mut toolbar_height = 0;
@@ -313,7 +318,7 @@ enum ButtonBase {
 impl ButtonBase {
   fn new_fit_width(text: &'static str, pos: Vector2<u32>, colors: &'static Palette) -> Self {
     let v_metrics = font::get_v_metrics();
-    let text_pos = [pos[0] as f64 + PADDING[0], pos[1] as f64 + PADDING[1] + v_metrics.ascent];
+    let text_pos = snap_pos([pos[0] as f64 + PADDING[0], pos[1] as f64 + PADDING[1] + v_metrics.ascent]);
     let plate_pos = [pos[0] as f64, pos[1] as f64];
     let plate_width = (font::get_width_metric_str(text) + PADDING[0] * 2.0).round();
     let plate_height = (v_metrics.ascent - v_metrics.descent + PADDING[1] * 2.0).round();
@@ -327,9 +332,9 @@ impl ButtonBase {
   fn new_double_text(text: [&'static str; 2], pos: Vector2<u32>, width: u32, colors: &'static Palette) -> Self {
     let v_metrics = font::get_v_metrics();
     let text_y = pos[1] as f64 + PADDING[1] + v_metrics.ascent;
-    let text_pos_left = [pos[0] as f64 + PADDING[0], text_y];
+    let text_pos_left = snap_pos([pos[0] as f64 + PADDING[0], text_y]);
     let text_width_right = font::get_width_metric_str(text[1]);
-    let text_pos_right = [pos[0] as f64 + width as f64 - text_width_right - PADDING[0], text_y];
+    let text_pos_right = snap_pos([pos[0] as f64 + width as f64 - text_width_right - PADDING[0], text_y]);
     let plate_pos = [pos[0] as f64, pos[1] as f64];
     let plate_height = (v_metrics.ascent - v_metrics.descent + PADDING[1] * 2.0).round();
     ButtonBase::BoxDoubleText {
@@ -409,8 +414,11 @@ struct TextComponent {
 
 impl TextComponent {
   fn draw(&self, ctx: Context, colors: &Palette, glyph_cache: &mut FontGlyphCache, gl: &mut GlGraphics) {
-    let transform = ctx.transform.trans_pos(self.pos);
-    graphics::text(colors.foreground, FONT_SIZE, self.text, glyph_cache, transform, gl)
+    let dpi_scale = font::dpi_scale() as f64;
+    let transform = ctx.transform.trans_pos(self.pos).scale(1.0 / dpi_scale, 1.0 / dpi_scale);
+    graphics::Text::new_color(colors.foreground, font::render_font_size())
+      .round()
+      .draw(self.text, glyph_cache, &ctx.draw_state, transform, gl)
       .expect("unable to draw text");
   }
 }

--- a/src/font.rs
+++ b/src/font.rs
@@ -12,20 +12,11 @@ use crate::error::Error;
 
 pub const FONT_SIZE: u32 = 11;
 const POINTS_TO_PIXELS: f32 = 4.0 / 3.0;
+const FONT_SCALE: Scale = Scale {
+  x: FONT_SIZE as f32 * POINTS_TO_PIXELS,
+  y: FONT_SIZE as f32 * POINTS_TO_PIXELS
+};
 static DPI_SCALE_BITS: AtomicU32 = AtomicU32::new(1.0f32.to_bits());
-
-#[inline]
-pub fn font_scale() -> Scale {
-  Scale {
-    x: logical_font_pixels(),
-    y: logical_font_pixels()
-  }
-}
-
-#[inline]
-pub fn logical_font_pixels() -> f32 {
-  FONT_SIZE as f32 * POINTS_TO_PIXELS
-}
 
 #[inline]
 pub fn dpi_scale() -> f32 {
@@ -57,7 +48,7 @@ fn get_font_ref() -> &'static Font<'static> {
 pub fn get_width_metric(ch: char) -> f64 {
   get_font_ref()
     .glyph(ch)
-    .scaled(font_scale())
+    .scaled(FONT_SCALE)
     .h_metrics()
     .advance_width
     as f64
@@ -68,7 +59,7 @@ pub fn get_width_metric_str(s: &str) -> f64 {
     .glyphs_for(s.chars())
     .map(|glyph| {
       glyph
-        .scaled(font_scale())
+        .scaled(FONT_SCALE)
         .h_metrics()
         .advance_width
     })
@@ -77,12 +68,12 @@ pub fn get_width_metric_str(s: &str) -> f64 {
 }
 
 pub fn get_height_metric() -> f64 {
-  let v_metrics = get_font_ref().v_metrics(font_scale());
+  let v_metrics = get_font_ref().v_metrics(FONT_SCALE);
   (v_metrics.ascent - v_metrics.descent) as f64
 }
 
 pub fn get_v_metrics() -> VMetrics {
-  let v_metrics = get_font_ref().v_metrics(font_scale());
+  let v_metrics = get_font_ref().v_metrics(FONT_SCALE);
   VMetrics {
     ascent: v_metrics.ascent as f64,
     descent: v_metrics.descent as f64

--- a/src/font.rs
+++ b/src/font.rs
@@ -1,6 +1,6 @@
 use chrono::Local;
-use fs_err as fs;
 use defy::Contextualize;
+use fs_err as fs;
 use once_cell::sync::Lazy;
 use rusttype::{Font, Scale};
 
@@ -13,97 +13,91 @@ use crate::error::Error;
 pub const FONT_SIZE: u32 = 11;
 const POINTS_TO_PIXELS: f32 = 4.0 / 3.0;
 const FONT_SCALE: Scale = Scale {
-  x: FONT_SIZE as f32 * POINTS_TO_PIXELS,
-  y: FONT_SIZE as f32 * POINTS_TO_PIXELS
+    x: FONT_SIZE as f32 * POINTS_TO_PIXELS,
+    y: FONT_SIZE as f32 * POINTS_TO_PIXELS,
 };
 static DPI_SCALE_BITS: AtomicU32 = AtomicU32::new(1.0f32.to_bits());
 
 #[inline]
 pub fn dpi_scale() -> f32 {
-  f32::from_bits(DPI_SCALE_BITS.load(Ordering::Relaxed))
+    f32::from_bits(DPI_SCALE_BITS.load(Ordering::Relaxed))
 }
 
 pub fn set_dpi_scale(scale: f64) {
-  DPI_SCALE_BITS.store((scale as f32).to_bits(), Ordering::Relaxed);
+    DPI_SCALE_BITS.store((scale as f32).to_bits(), Ordering::Relaxed);
 }
 
 pub fn render_font_size() -> u32 {
-  ((FONT_SIZE as f32) * dpi_scale()).round().max(1.0) as u32
+    ((FONT_SIZE as f32) * dpi_scale()).round().max(1.0) as u32
 }
 
 pub fn get_font() -> Font<'static> {
-  get_font_ref().clone()
+    get_font_ref().clone()
 }
 
 fn get_font_ref() -> &'static Font<'static> {
-  const FONT_DATA: &[u8] = include_bytes!("../assets/Inconsolata-Regular.ttf");
-  static FONT: Lazy<Font<'static>> = Lazy::new(|| {
-    Font::try_from_bytes(FONT_DATA)
-      .expect("unable to load font")
-  });
+    const FONT_DATA: &[u8] = include_bytes!("../assets/Inconsolata-Regular.ttf");
+    static FONT: Lazy<Font<'static>> =
+        Lazy::new(|| Font::try_from_bytes(FONT_DATA).expect("unable to load font"));
 
-  &*FONT
+    &*FONT
 }
 
 pub fn get_width_metric(ch: char) -> f64 {
-  get_font_ref()
-    .glyph(ch)
-    .scaled(FONT_SCALE)
-    .h_metrics()
-    .advance_width
-    as f64
+    get_font_ref()
+        .glyph(ch)
+        .scaled(FONT_SCALE)
+        .h_metrics()
+        .advance_width as f64
 }
 
 pub fn get_width_metric_str(s: &str) -> f64 {
-  get_font_ref()
-    .glyphs_for(s.chars())
-    .map(|glyph| {
-      glyph
-        .scaled(FONT_SCALE)
-        .h_metrics()
-        .advance_width
-    })
-    .sum::<f32>()
-    as f64
+    get_font_ref()
+        .glyphs_for(s.chars())
+        .map(|glyph| glyph.scaled(FONT_SCALE).h_metrics().advance_width)
+        .sum::<f32>() as f64
 }
 
 pub fn get_height_metric() -> f64 {
-  let v_metrics = get_font_ref().v_metrics(FONT_SCALE);
-  (v_metrics.ascent - v_metrics.descent) as f64
+    let v_metrics = get_font_ref().v_metrics(FONT_SCALE);
+    (v_metrics.ascent - v_metrics.descent) as f64
 }
 
 pub fn get_v_metrics() -> VMetrics {
-  let v_metrics = get_font_ref().v_metrics(FONT_SCALE);
-  VMetrics {
-    ascent: v_metrics.ascent as f64,
-    descent: v_metrics.descent as f64
-  }
+    let v_metrics = get_font_ref().v_metrics(FONT_SCALE);
+    VMetrics {
+        ascent: v_metrics.ascent as f64,
+        descent: v_metrics.descent as f64,
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct VMetrics {
-  pub ascent: f64,
-  pub descent: f64
+    pub ascent: f64,
+    pub descent: f64,
 }
 
 pub fn view_font_license() -> Result<(), Error> {
-  const LICENSE_CONTENTS: &[u8] = include_bytes!("../assets/Inconsolata-OFL.txt");
+    const LICENSE_CONTENTS: &[u8] = include_bytes!("../assets/Inconsolata-OFL.txt");
 
-  let now = Local::now().format("%Y%m%d-%H%M%S");
-  let path = env::temp_dir().join(format!("Inconsolata-OFL-{}.txt", now));
+    let now = Local::now().format("%Y%m%d-%H%M%S");
+    let path = env::temp_dir().join(format!("Inconsolata-OFL-{}.txt", now));
 
-  fs::write(&path, LICENSE_CONTENTS)
-    .context("Failed to write font license to disk")?;
+    fs::write(&path, LICENSE_CONTENTS).context("Failed to write font license to disk")?;
 
-  if cfg!(target_os = "windows") {
-    Command::new("notepad").arg(path).spawn()
-      .context("Failed to open license")?;
-  } else if cfg!(target_os = "macos") {
-    Command::new("open").arg(path).spawn()
-      .context("Failed to open license")?;
-  } else {
-    unimplemented!()
-  };
+    if cfg!(target_os = "windows") {
+        Command::new("notepad")
+            .arg(path)
+            .spawn()
+            .context("Failed to open license")?;
+    } else if cfg!(target_os = "macos") {
+        Command::new("open")
+            .arg(path)
+            .spawn()
+            .context("Failed to open license")?;
+    } else {
+        unimplemented!()
+    };
 
-  Ok(())
+    Ok(())
 }

--- a/src/font.rs
+++ b/src/font.rs
@@ -4,13 +4,41 @@ use defy::Contextualize;
 use once_cell::sync::Lazy;
 use rusttype::{Font, Scale};
 
-use std::process::Command;
 use std::env;
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use crate::error::Error;
 
 pub const FONT_SIZE: u32 = 11;
-const FONT_SCALE: Scale = Scale { x: 15.0, y: 15.0 };
+const POINTS_TO_PIXELS: f32 = 4.0 / 3.0;
+static DPI_SCALE_BITS: AtomicU32 = AtomicU32::new(1.0f32.to_bits());
+
+#[inline]
+pub fn font_scale() -> Scale {
+  Scale {
+    x: logical_font_pixels(),
+    y: logical_font_pixels()
+  }
+}
+
+#[inline]
+pub fn logical_font_pixels() -> f32 {
+  FONT_SIZE as f32 * POINTS_TO_PIXELS
+}
+
+#[inline]
+pub fn dpi_scale() -> f32 {
+  f32::from_bits(DPI_SCALE_BITS.load(Ordering::Relaxed))
+}
+
+pub fn set_dpi_scale(scale: f64) {
+  DPI_SCALE_BITS.store((scale as f32).to_bits(), Ordering::Relaxed);
+}
+
+pub fn render_font_size() -> u32 {
+  ((FONT_SIZE as f32) * dpi_scale()).round().max(1.0) as u32
+}
 
 pub fn get_font() -> Font<'static> {
   get_font_ref().clone()
@@ -29,7 +57,7 @@ fn get_font_ref() -> &'static Font<'static> {
 pub fn get_width_metric(ch: char) -> f64 {
   get_font_ref()
     .glyph(ch)
-    .scaled(FONT_SCALE)
+    .scaled(font_scale())
     .h_metrics()
     .advance_width
     as f64
@@ -40,7 +68,7 @@ pub fn get_width_metric_str(s: &str) -> f64 {
     .glyphs_for(s.chars())
     .map(|glyph| {
       glyph
-        .scaled(FONT_SCALE)
+        .scaled(font_scale())
         .h_metrics()
         .advance_width
     })
@@ -49,12 +77,12 @@ pub fn get_width_metric_str(s: &str) -> f64 {
 }
 
 pub fn get_height_metric() -> f64 {
-  let v_metrics = get_font_ref().v_metrics(FONT_SCALE);
+  let v_metrics = get_font_ref().v_metrics(font_scale());
   (v_metrics.ascent - v_metrics.descent) as f64
 }
 
 pub fn get_v_metrics() -> VMetrics {
-  let v_metrics = get_font_ref().v_metrics(FONT_SCALE);
+  let v_metrics = get_font_ref().v_metrics(font_scale());
   VMetrics {
     ascent: v_metrics.ascent as f64,
     descent: v_metrics.descent as f64

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ pub const APPNAME: &str = concat!("HOI4 Province Map Editor v", env!("CARGO_PKG_
 
 fn main() {
   install_handler();
+  enable_dpi_awareness();
 
   let root = root_dir().expect("unable to find root dir");
   env::set_current_dir(root).expect("unable to set root dir");
@@ -44,6 +45,21 @@ fn main() {
   let mut gl = GlGraphics::new(opengl);
   launch::<App>(&mut window, &mut gl);
 }
+
+#[cfg(target_os = "windows")]
+fn enable_dpi_awareness() {
+  use windows_sys::Win32::UI::HiDpi::{
+    DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2,
+    SetProcessDpiAwarenessContext,
+  };
+
+  unsafe {
+    let _ = SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+  }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn enable_dpi_awareness() {}
 
 fn root_dir() -> io::Result<PathBuf> {
   if let Some(manifest_dir) = env::var_os("CARGO_MANIFEST_DIR") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ fn main() {
 
 #[cfg(target_os = "windows")]
 fn enable_dpi_awareness() {
-  use windows_sys::Win32::UI::HiDpi::{
+  use windows::Win32::UI::HiDpi::{
     DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2,
     SetProcessDpiAwarenessContext,
   };


### PR DESCRIPTION
## Summary

This updates menu text rendering to stay sharp on high-DPI displays, especially on Windows systems using display scaling such as 150%.

## Changes

- enable per-monitor DPI awareness on Windows
- render menu text using DPI-scaled glyph sizes instead of scaling up low-resolution glyph textures
- keep menu layout in logical window coordinates while drawing text at physical pixel density
- align menu text positions to pixel boundaries for cleaner rendering

## Result

Menu bar text and dropdown text now render clearly instead of appearing blurry on scaled displays.

## Verification

- built with `cargo check`
- verified locally on a Windows system with 150% display scaling

## Screenshots

Before / after screenshots attached below.

<img width="1941" height="1136" alt="image" src="https://github.com/user-attachments/assets/60607dcb-a5b1-46bc-8dda-6d4b969eab64" />
<img width="1941" height="1134" alt="image" src="https://github.com/user-attachments/assets/9684cfe0-92d6-45cd-b7c1-28da41abeb8e" />
