### PR TITLE
feat: show tooltips for sidebar tools

### DIFF
--- a/src/app/interface.rs
+++ b/src/app/interface.rs
@@ -281,20 +281,27 @@ impl ButtonElement {
 
   fn tooltip(&self, view_mode: Option<ViewMode>) -> Option<&'static str> {
     use ButtonId::*;
+    let view_mode = view_mode?;
 
     match (self.id, view_mode) {
-      (SidebarToolPaintArea, Some(ViewMode::Color | ViewMode::Kind | ViewMode::Terrain | ViewMode::Continent)) =>
-        Some("Paint Area: drag to paint provinces under the brush."),
-      (SidebarToolPaintBucket, Some(ViewMode::Color)) =>
-        Some("Paint Bucket: fill the hovered province with the current brush."),
-      (SidebarToolLasso, Some(ViewMode::Color)) =>
-        Some("Lasso: draw a custom selection and then apply the current brush."),
-      (SidebarOptionProvinceIds, Some(_)) =>
-        Some("Toggle Province IDs: show or hide province numbers on the map."),
-      (SidebarOptionProvinceBoundaries, Some(_)) =>
-        Some("Toggle Province Boundaries: show or hide province borders."),
-      (SidebarOptionRiverOverlay, Some(_)) =>
-        Some("Toggle Rivers Overlay: show or hide river data on top of the map."),
+      (SidebarToolPaintArea, ViewMode::Color) =>
+        Some("Paint Area: Drag to paint provinces under the brush"),
+      (SidebarToolPaintArea, ViewMode::Kind) =>
+        Some("Paint Area: Drag to assign province types"),
+      (SidebarToolPaintArea, ViewMode::Terrain) =>
+        Some("Paint Area: Drag to assign province terrain types"),
+      (SidebarToolPaintArea, ViewMode::Continent) =>
+        Some("Paint Area: Drag to assign provinces to continents"),
+      (SidebarToolPaintBucket, ViewMode::Color) =>
+        Some("Paint Bucket: Fill the hovered province with the current brush"),
+      (SidebarToolLasso, ViewMode::Color) =>
+        Some("Lasso: Draw a custom selection and then apply the current brush"),
+      (SidebarOptionProvinceIds, ..) =>
+        Some("Toggle Province IDs: Show or hide province IDs on the map"),
+      (SidebarOptionProvinceBoundaries, ..) =>
+        Some("Toggle Province Boundaries: Show or hide province borders"),
+      (SidebarOptionRiverOverlay, ..) =>
+        Some("Toggle Rivers Overlay: Show or hide the contents of rivers.bmp"),
       _ => None
     }
   }

--- a/src/app/interface.rs
+++ b/src/app/interface.rs
@@ -19,7 +19,11 @@ use std::fmt;
 pub const PADDING: Vector2<f64> = [6.0, 4.0];
 const TOOLTIP_OFFSET_X: f64 = 8.0;
 const TOOLTIP_MIN_WIDTH: f64 = 180.0;
-const TOOLTIP_MAX_WIDTH: f64 = 280.0;
+
+#[inline]
+fn snap_pos([x, y]: Vector2<f64>) -> Vector2<f64> {
+  [x.round(), y.round()]
+}
 
 const PALETTE_BUTTON: Palette = Palette {
   foreground: colors::WHITE,
@@ -543,10 +547,10 @@ fn draw_tooltip(
 ) {
   let v_metrics = font::get_v_metrics();
   let text_width = font::get_width_metric_str(text).round();
-  let plate_width = text_width.max(TOOLTIP_MIN_WIDTH).min(TOOLTIP_MAX_WIDTH) + PADDING[0] * 2.0;
+  let plate_width = text_width.max(TOOLTIP_MIN_WIDTH) + PADDING[0] * 2.0;
   let plate_height = (v_metrics.ascent - v_metrics.descent + PADDING[1] * 2.0).round();
-  let plate_pos = [anchor[0] + TOOLTIP_OFFSET_X, anchor[1] - plate_height / 2.0];
-  let text_pos = [plate_pos[0] + PADDING[0], plate_pos[1] + PADDING[1] + v_metrics.ascent];
+  let plate_pos = snap_pos([anchor[0] + TOOLTIP_OFFSET_X, anchor[1] - plate_height / 2.0]);
+  let text_pos = snap_pos([plate_pos[0] + PADDING[0], plate_pos[1] + PADDING[1] + v_metrics.ascent]);
 
   graphics::rectangle(colors::OVERLAY_T, [
     plate_pos[0], plate_pos[1],

--- a/src/app/interface.rs
+++ b/src/app/interface.rs
@@ -17,6 +17,9 @@ use std::sync::Arc;
 use std::fmt;
 
 pub const PADDING: Vector2<f64> = [6.0, 4.0];
+const TOOLTIP_OFFSET_X: f64 = 8.0;
+const TOOLTIP_MIN_WIDTH: f64 = 180.0;
+const TOOLTIP_MAX_WIDTH: f64 = 280.0;
 
 const PALETTE_BUTTON: Palette = Palette {
   foreground: colors::WHITE,
@@ -203,6 +206,7 @@ impl Interface {
     glyph_cache: &mut FontGlyphCache,
     gl: &mut GlGraphics
   ) {
+    let mut sidebar_tooltip = None;
     self.sidebar_plate.draw(ctx, false, false, gl);
 
     for (i, sidebar_button) in self.sidebar_tool_buttons.iter().enumerate() {
@@ -217,15 +221,27 @@ impl Interface {
       };
 
       let hover = sidebar_button.base.test_maybe(pos);
+      if hover {
+        sidebar_tooltip = sidebar_button.tooltip(ictx.view_mode)
+          .map(|text| (sidebar_button.base.tooltip_anchor(), text));
+      }
       let active = Some(i) == selected_tool;
       sidebar_button.base.draw(ctx, hover, active, glyph_cache, gl);
     };
 
     for (i, sidebar_button) in self.sidebar_option_buttons.iter().enumerate() {
       let hover = sidebar_button.base.test_maybe(pos);
+      if hover {
+        sidebar_tooltip = sidebar_button.tooltip(ictx.view_mode)
+          .map(|text| (sidebar_button.base.tooltip_anchor(), text));
+      }
       let active = ictx.enabled_options[i];
       sidebar_button.base.draw(ctx, hover, active, glyph_cache, gl);
     };
+
+    if let Some((anchor, text)) = sidebar_tooltip {
+      draw_tooltip(ctx, text, anchor, glyph_cache, gl);
+    }
 
     self.toolbar_plate.draw(ctx, false, false, gl);
 
@@ -257,6 +273,26 @@ impl ButtonElement {
 
   fn draw(&self, ctx: Context, pos: Option<Vector2<f64>>, active: bool, glyph_cache: &mut FontGlyphCache, gl: &mut GlGraphics) {
     self.base.draw(ctx, self.base.test_maybe(pos), active, glyph_cache, gl);
+  }
+
+  fn tooltip(&self, view_mode: Option<ViewMode>) -> Option<&'static str> {
+    use ButtonId::*;
+
+    match (self.id, view_mode) {
+      (SidebarToolPaintArea, Some(ViewMode::Color | ViewMode::Kind | ViewMode::Terrain | ViewMode::Continent)) =>
+        Some("Paint Area: drag to paint provinces under the brush."),
+      (SidebarToolPaintBucket, Some(ViewMode::Color)) =>
+        Some("Paint Bucket: fill the hovered province with the current brush."),
+      (SidebarToolLasso, Some(ViewMode::Color)) =>
+        Some("Lasso: draw a custom selection and then apply the current brush."),
+      (SidebarOptionProvinceIds, Some(_)) =>
+        Some("Toggle Province IDs: show or hide province numbers on the map."),
+      (SidebarOptionProvinceBoundaries, Some(_)) =>
+        Some("Toggle Province Boundaries: show or hide province borders."),
+      (SidebarOptionRiverOverlay, Some(_)) =>
+        Some("Toggle Rivers Overlay: show or hide river data on top of the map."),
+      _ => None
+    }
   }
 }
 
@@ -399,6 +435,11 @@ impl ButtonBase {
       ButtonBase::BoxTexture { plate, .. } => plate
     }
   }
+
+  fn tooltip_anchor(&self) -> Vector2<f64> {
+    let plate = self.plate();
+    [plate.pos[0] + plate.size[0], plate.pos[1] + plate.size[1] / 2.0]
+  }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -491,6 +532,30 @@ struct Palette {
   background_active: DrawColor,
   background_hover: DrawColor,
   background_hover_active: DrawColor
+}
+
+fn draw_tooltip(
+  ctx: Context,
+  text: &'static str,
+  anchor: Vector2<f64>,
+  glyph_cache: &mut FontGlyphCache,
+  gl: &mut GlGraphics
+) {
+  let v_metrics = font::get_v_metrics();
+  let text_width = font::get_width_metric_str(text).round();
+  let plate_width = text_width.max(TOOLTIP_MIN_WIDTH).min(TOOLTIP_MAX_WIDTH) + PADDING[0] * 2.0;
+  let plate_height = (v_metrics.ascent - v_metrics.descent + PADDING[1] * 2.0).round();
+  let plate_pos = [anchor[0] + TOOLTIP_OFFSET_X, anchor[1] - plate_height / 2.0];
+  let text_pos = [plate_pos[0] + PADDING[0], plate_pos[1] + PADDING[1] + v_metrics.ascent];
+
+  graphics::rectangle(colors::OVERLAY_T, [
+    plate_pos[0], plate_pos[1],
+    plate_width, plate_height
+  ], ctx.transform, gl);
+
+  let transform = ctx.transform.trans_pos(text_pos);
+  graphics::text(colors::WHITE, FONT_SIZE, text, glyph_cache, transform, gl)
+    .expect("unable to draw tooltip text");
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
## Summary

This adds hover tooltips to the left sidebar so users can quickly understand what each tool and display toggle does.

## Changes

- show a tooltip when hovering sidebar tool buttons
- show a tooltip when hovering sidebar display toggle buttons
- place the tooltip next to the hovered sidebar button
- keep the implementation lightweight inside the existing custom UI rendering path

## Result

The sidebar is easier to learn and use, especially for first-time users who are not yet familiar with the tool icons.

## Verification

- built with `cargo check`

## Screenshots

Screenshot attached below.


<img width="1941" height="1134" alt="image" src="https://github.com/user-attachments/assets/7440b114-57eb-41b9-9c49-aed65d6f649b" />